### PR TITLE
new structs version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.10</version>
+            <version>308.v852b473a2b8c</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
With Java 11, `mvn compile` worked but `mvn package` failed for me with this error:
```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
Running tests for org.jenkins-ci.plugins:google-chat-notification:1.6-SNAPSHOT
[INFO] Running InjectedTest
[ERROR] Tests run: 6, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 7.149 s <<< FAILURE! - in InjectedTest
[ERROR] InjectedTest.testPluginActive  Time elapsed: 0.001 s  <<< FAILURE!
java.lang.AssertionError: While testing google-chat-notification, workflow-step-api failed to start
...
	at java.base/java.lang.Thread.run(Thread.java:1589)
Caused by: java.io.IOException: Failed to load: Pipeline: Step API (workflow-step-api 625.vd896b_f445a_f8)
 - Update required: Structs Plugin (structs 1.10) to be updated to 308.v852b473a2b8c or higher
```
It builds ok after updating the structs version in pom.xml.
My Java version:
```
% java --version
openjdk 11.0.18 2023-01-17
OpenJDK Runtime Environment Temurin-11.0.18+10 (build 11.0.18+10)
OpenJDK 64-Bit Server VM Temurin-11.0.18+10 (build 11.0.18+10, mixed mode
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

