### PR TITLE
Don't use deprecated org.apache.commons.httpclient

### DIFF
--- a/src/main/java/io/cnaik/service/CommonUtil.java
+++ b/src/main/java/io/cnaik/service/CommonUtil.java
@@ -7,11 +7,11 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 
-import org.apache.commons.httpclient.util.URIUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
+import org.springframework.web.util.UriUtils;
 
 import hudson.FilePath;
 import hudson.model.Result;
@@ -172,7 +172,7 @@ public class CommonUtil {
                 String threadKey;
                 if (googleChatNotification.isSameThreadNotification()) {
                     threadKey = StringUtils.defaultIfBlank(googleChatNotification.getThreadKey(), getJobName());
-                    urlDetail = urlDetail + "&threadKey=" + URIUtil.encodePath(threadKey);
+                    urlDetail = urlDetail + "&threadKey=" + UriUtils.encodePath(threadKey, "UTF-8");
 
                     if (logUtil.printLogEnabled()) {
                         logUtil.printLog("Will send message to the thread: " + threadKey);


### PR DESCRIPTION
Calling `googlechatnotification` in a pipeline on Jenkins 2.387 fails with this error:
```
java.lang.ClassNotFoundException: org.apache.commons.httpclient.util.URIUtil
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
	at jenkins.util.URLClassLoader2.findClass(URLClassLoader2.java:35)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
Caused: java.lang.NoClassDefFoundError: org/apache/commons/httpclient/util/URIUtil
	at io.cnaik.service.CommonUtil.call(CommonUtil.java:175)
	at io.cnaik.service.CommonUtil.notifyForEachUrl(CommonUtil.java:89)
	at io.cnaik.service.CommonUtil.send(CommonUtil.java:66)
	at io.cnaik.GoogleChatNotification.performAction(GoogleChatNotification.java:399)
	at io.cnaik.GoogleChatNotification.perform(GoogleChatNotification.java:241)
	at jenkins.tasks.SimpleBuildStep.perform(SimpleBuildStep.java:123)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:101)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:71)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```
https://javadoc.io/static/commons-httpclient/commons-httpclient/3.1-jenkins-1/org/apache/commons/httpclient/util/URIUtil.html says:

> Jakarta Commons HttpClient 3.x is deprecated in the Jenkins project. It is not recommended to use it in any new code. Instead, use HTTP client API plugins as a dependency in your code. E.g. Apache HttpComponents Client API 4.x Plugin or Async HTTP Client Plugin.

It seems it is not just deprecated, but actually removed from Jenkins. 

As noted in that quote, one fix for this would be to add a dependency on an API plugin such as [apache-httpcomponents-client-4-api](https://plugins.jenkins.io/apache-httpcomponents-client-4-api/), and use [URIBuilder](https://stackoverflow.com/a/59241171/4926210). Or we could use Java's [URI class](https://docs.oracle.com/javase/8/docs/api/java/net/URI.html#URI-java.lang.String-java.lang.String-java.lang.String-int-java.lang.String-java.lang.String-java.lang.String-). Instead, I added back the `org.springframework.web.util.UriUtils` import that was [recently removed](https://github.com/jenkinsci/google-chat-notification-plugin/commit/ca29509de9d1a0cc38aa4e0188a040a9134f3c5f#diff-b76cf5a397b74f62edb96d61bdd83c2766c0ed59acd8d9b9fcae2f93b14aac14L13) because it was unused.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
