### PR TITLE
fix: Correctly processing unicode characters

### DIFF
--- a/src/main/java/io/cnaik/service/ResponseMessageUtil.java
+++ b/src/main/java/io/cnaik/service/ResponseMessageUtil.java
@@ -3,6 +3,7 @@ package io.cnaik.service;
 import java.io.IOException;
 import java.util.Locale;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
@@ -42,7 +43,7 @@ public class ResponseMessageUtil {
             thread = createThreadJson();
         }
 
-        var text = escapeSpecialCharacter(replaceJenkinsKeywords(googleChatNotification.getMessage()));
+        var text = StringEscapeUtils.unescapeJava(replaceJenkinsKeywords(googleChatNotification.getMessage()));
 
         var json = new JSONObject();
         json.put("text", text);
@@ -92,19 +93,6 @@ public class ResponseMessageUtil {
         }
 
         return thread;
-    }
-
-    private String escapeSpecialCharacter(String input) {
-
-        String output = input;
-
-        if (StringUtils.isNotEmpty(output)) {
-            output = output.replace("{", "\\{");
-            output = output.replace("}", "\\}");
-            output = output.replace("'", "\\'");
-        }
-
-        return output;
     }
 
     private String replaceJenkinsKeywords(String inputString) {


### PR DESCRIPTION
Unescapes any Java literals found in the String passed as message to Google Chat.

Fixes #47

### Testing done

Buggy message x fixed message
![image](https://github.com/jenkinsci/google-chat-notification-plugin/assets/8527036/85c14761-dca0-4123-9d00-734f96821884)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
