### PR TITLE
Fix plugin waiting for checkpoint

### DIFF
--- a/src/main/java/io/cnaik/GoogleChatNotification.java
+++ b/src/main/java/io/cnaik/GoogleChatNotification.java
@@ -247,7 +247,7 @@ public class GoogleChatNotification extends Notifier implements SimpleBuildStep 
 
     @Override
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     @Symbol("googlechatnotification")


### PR DESCRIPTION
This solve the issue https://github.com/jenkinsci/google-chat-notification-plugin/issues/8

This was inspired in https://github.com/jenkinsci/gitlab-plugin/pull/397/commits/2fd683ed3b88e6c5424abd807e387d56e7ce34fe

The complete documentation of method "getRequiredMonitorService" can be found in https://javadoc.jenkins.io/hudson/tasks/BuildStep.html

Below is an excerpt from the documentation.

> [BuildStepMonitor.NONE](https://javadoc.jenkins.io/hudson/tasks/BuildStepMonitor.html#NONE)
> No external synchronization is performed on this build step. This is the most efficient, and thus the recommended value for newer plugins.

> - If your build step doesn't use anything from a previous build (for example, if you don't even call [Run.getPreviousBuild()](https://javadoc.jenkins.io/hudson/model/Run.html#getPreviousBuild())), then you can return [BuildStepMonitor.NONE](https://javadoc.jenkins.io/hudson/tasks/BuildStepMonitor.html#NONE) without making further code changes and you are done with migration.

I had the following problem. A build was waiting for another build to finish. The message was

> Google Chat Notification is waiting for a checkpoint on build...

This way, the build was stuck at the step of sending the notification via Google Chat.

My Job is configured to run a maximum of two builds per node. Some builds run quickly. Other builds take up to 3 days. It is not interesting for the build to wait for another build to execute to send the notification.

After I used the plugin with this modification, the problem did not occur again.