### PR TITLE
fix: Fix the messageFormat param handling in scripted pipelines

### DIFF
--- a/src/main/java/io/cnaik/GoogleChatNotification.java
+++ b/src/main/java/io/cnaik/GoogleChatNotification.java
@@ -68,6 +68,11 @@ public class GoogleChatNotification extends Notifier implements SimpleBuildStep 
     }
 
     @DataBoundSetter
+    public void setMessageFormat(@QueryParameter("messageFormat") final String messageFormat) {
+        this.messageFormat = messageFormat != null ? MessageFormat.valueOf(messageFormat.toUpperCase()) : null;
+    }
+
+    @DataBoundSetter
     public void setSameThreadNotification(boolean sameThreadNotification) {
         this.sameThreadNotification = sameThreadNotification;
     }
@@ -382,7 +387,7 @@ public class GoogleChatNotification extends Notifier implements SimpleBuildStep 
         public MessageFormat getMessageFormat() {
             return messageFormat != null ? messageFormat : defaultMessageFormat;
         }
-
+        
         public boolean isSameThreadNotification() {
             return sameThreadNotification;
         }

--- a/src/main/java/io/cnaik/GoogleChatNotification.java
+++ b/src/main/java/io/cnaik/GoogleChatNotification.java
@@ -1,5 +1,7 @@
 package io.cnaik;
 
+import java.util.Locale;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.Symbol;
 import org.json.JSONException;
@@ -69,7 +71,7 @@ public class GoogleChatNotification extends Notifier implements SimpleBuildStep 
 
     @DataBoundSetter
     public void setMessageFormat(@QueryParameter("messageFormat") final String messageFormat) {
-        this.messageFormat = messageFormat != null ? MessageFormat.valueOf(messageFormat.toUpperCase()) : null;
+        this.messageFormat = messageFormat != null ? MessageFormat.valueOf(messageFormat.toUpperCase(Locale.ROOT)) : null;
     }
 
     @DataBoundSetter


### PR DESCRIPTION
Fixes #65

Fixed the `messageFormat` param handling in scripted pipelines. Bug introduced in v.1.8.0.

### Testing done

**Before, with bug:**

![image](https://github.com/jenkinsci/google-chat-notification-plugin/assets/8527036/d1f12b16-5b19-448a-82a3-09e5938ac994)

**After, fixed:**

![image](https://github.com/jenkinsci/google-chat-notification-plugin/assets/8527036/03f6734a-6585-43fa-a763-158b5a1afc5c)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

