### PR TITLE
fix: Re-enable the possibility of send notification before build result

### DIFF
--- a/src/main/java/io/cnaik/GoogleChatNotification.java
+++ b/src/main/java/io/cnaik/GoogleChatNotification.java
@@ -64,7 +64,6 @@ public class GoogleChatNotification extends Notifier implements SimpleBuildStep 
         this.message = message;
     }
 
-    @DataBoundSetter
     public void setMessageFormat(MessageFormat messageFormat) {
         this.messageFormat = messageFormat;
     }

--- a/src/main/java/io/cnaik/service/CommonUtil.java
+++ b/src/main/java/io/cnaik/service/CommonUtil.java
@@ -52,7 +52,8 @@ public class CommonUtil {
     }
 
     private boolean checkWhetherToSend() {
-        if (build == null || build.getResult() == null || googleChatNotification == null) {
+        if (build == null || googleChatNotification == null) {
+            // build.getResult() == null for builds that didn't finish yet
             return false;
         } else {
             var conditions = NotificationConditions.create(googleChatNotification, logUtil.getLogger());


### PR DESCRIPTION
Fixes #69

### Testing done

**Before, with bug**:

![image](https://github.com/jenkinsci/google-chat-notification-plugin/assets/8527036/ad2a7e17-6acc-489e-b1a1-9b1fe7b70434)

**After, fixed**:

![image](https://github.com/jenkinsci/google-chat-notification-plugin/assets/8527036/7933d339-177c-4a8b-9065-89aff1627561)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
