### PR TITLE
fix: Some conditions for sending notification was being ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This Jenkins plugin allows you to send Google Chat notification as a post build 
 
 ## Pipeline job
 
-### Simpliest configuration
+### Minimal configuration
 
     googlechatnotification url: 'web hook(s) URL(s)', message: 'message to be sent'
 

--- a/src/main/java/jenkins/plugins/googlechat/decisions/NotificationConditions.java
+++ b/src/main/java/jenkins/plugins/googlechat/decisions/NotificationConditions.java
@@ -19,6 +19,9 @@ public class NotificationConditions implements Predicate<Context> {
         return new NotificationConditions(Arrays.asList(
                 new OnAborted(preferences, log),
                 new OnSingleFailure(preferences, log),
+                new OnRepeatedFailure(preferences, log),
+                new OnEveryFailure(preferences, log),
+                new OnRegression(preferences, log),
                 new OnNotBuilt(preferences, log),
                 new OnBackToNormal(preferences, log),
                 new OnSuccess(preferences, log),


### PR DESCRIPTION
Fixes #74

### Testing done

**With a simple pipeline**:
```
pipeline {
    agent { label 'xxx-linux-agent' }
    stages {
        stage('Test') {
            steps {
                sh '''
                    echo '[{"code":"DL3059","column":1,"file":"Dockerfile","level":"info","line":47,"message":"Multiple consecutive `RUN` instructions. Consider consolidation."}]' > hadolint.json
                '''
            }
        }
    }
    post {
        always {
            recordIssues failedTotalAll: 1, enabledForFailure: true, tool: hadoLint(pattern: "hadolint.json")
            googlechatnotification url: 'xxx-url', message: '${PROJECT_NAME} : Build #${BUILD_NUMBER} - ${BUILD_STATUS} - Issues: ${ANALYSIS_ISSUES_COUNT}\n\nCheck output at ${BUILD_URL}', notifyAborted: 'true', notifyFailure: 'true', notifyNotBuilt: 'true', notifySuccess: 'true', notifyUnstable: 'true', notifyBackToNormal: 'true', suppressInfoLoggers: 'false', sameThreadNotification: 'true'
        }
    }
}
```

**Build log before the fix**:

![image](https://github.com/jenkinsci/google-chat-notification-plugin/assets/8527036/6c3d86ea-6d7f-4b14-bc24-d0091f2b6abd)

**Build log after the fix**:

![image](https://github.com/jenkinsci/google-chat-notification-plugin/assets/8527036/1d3f306a-b03a-4cbf-8955-81bfaaf6f8af)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
